### PR TITLE
Forgotten your@email.com on the action url

### DIFF
--- a/pages/publicaciones/libros/angularjs.html
+++ b/pages/publicaciones/libros/angularjs.html
@@ -62,7 +62,7 @@ description: "Libro práctico y paso a paso de AngularJS"
     </ul>
 
     <p>Déjanos tu mail y estaremos encantados en avistarte cuando este a la venta el libro.</p>
-    <form class="form-horizontal" id="contact-form" method="POST" action="//formspree.io/">
+    <form class="form-horizontal" id="contact-form" method="POST" action="//formspree.io/your@email.com">
         <div class="form-group">
             <label for="inputEmail3" class="col-xs-12 col-sm-2 control-label">Tu email:</label>
             <div class="col-xs-12 col-sm-10">


### PR DESCRIPTION
Following the documentation [http://formspree.io/#getstarted] for formspree.io submiting forms the `action` should have this value http://formspree.io/your@email.com (with your user email instead)

Instead with the actual implementation trying to submit an email I got this error from formspree.io:
Method Not Allowed
The method is not allowed for the requested URL.
